### PR TITLE
fix(policies): remove policies limit

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -154,6 +154,4 @@ collections:
         widget: 'number',
         required: true,
         valueType: int,
-        min: 1,
-        max: 20,
       }


### PR DESCRIPTION
Admins should be able to create unlimited number of policy documents